### PR TITLE
feat: melhorias nas páginas de contagens

### DIFF
--- a/app/components/Contagens/CountingComparisionTable.tsx
+++ b/app/components/Contagens/CountingComparisionTable.tsx
@@ -5,6 +5,7 @@ import { Link } from "@remix-run/react";
 import { ColumnFilter, NumberRangeColumnFilter } from "~/components/Commom/Table/TableFilters";
 import Table from "~/components/Commom/Table/Table";
 import { IntlDateStr } from "~/services/utils";
+import { contagemSlug } from "~/utils/slugify";
 
 function fuzzyTextFilterFn(rows: any[], id: string, filterValue: string) {
   return matchSorter(rows, filterValue, { keys: [(row: any) => row.values[id]] });
@@ -55,15 +56,20 @@ export const CountingComparisionTable = ({ data, firstSlug }: { data: any[], fir
       {
         Header: "Nome",
         accessor: "name",
-        Cell: ({ row }: { row: any }) => (
-          <Link
-            className="text-ameciclo"
-            to={`/dados/contagens/${row.original.id}`}
-            key={row.original.id}
-          >
-            {row.original.name}
-          </Link>
-        ),
+        Cell: ({ row }: { row: any }) => {
+          const slug = row.original.date
+            ? contagemSlug(row.original.date, row.original.name)
+            : String(row.original.id);
+          return (
+            <Link
+              className="text-ameciclo"
+              to={`/dados/contagens/${slug}`}
+              key={row.original.id}
+            >
+              {row.original.name}
+            </Link>
+          );
+        },
         Filter: ColumnFilter,
       },
       {
@@ -87,15 +93,20 @@ export const CountingComparisionTable = ({ data, firstSlug }: { data: any[], fir
       },
       {
         Header: "COMPARE",
-        accessor: "compare", // Adiciona accessor
-        Cell: ({ row }: { row: any }) => (
-          <Link
-            className="text-ameciclo hover:underline font-medium"
-            to={`/dados/contagens/${firstSlug}/compare/${row.original.id}`}
-          >
-            COMPARE
-          </Link>
-        ),
+        accessor: "compare",
+        Cell: ({ row }: { row: any }) => {
+          const compareSlug = row.original.date
+            ? contagemSlug(row.original.date, row.original.name)
+            : String(row.original.id);
+          return (
+            <Link
+              className="text-ameciclo hover:underline font-medium"
+              to={`/dados/contagens/${firstSlug}/compare/${compareSlug}`}
+            >
+              COMPARE
+            </Link>
+          );
+        },
         disableFilters: true,
         disableSortBy: true,
       },

--- a/app/components/Contagens/CountsTable.tsx
+++ b/app/components/Contagens/CountsTable.tsx
@@ -1,9 +1,10 @@
-import { Link } from "@remix-run/react";
+import { Link } from "@tanstack/react-router";
 import React, { useState, useMemo } from "react";
 import type { ContagemData } from "~/services/contagens.service";
 import { IntlDateStr } from "~/services/utils";
 import Table from "~/components/Commom/Table/Table";
 import { ColumnFilter } from "~/components/Commom/Table/TableFilters";
+import { contagemSlug } from "~/utils/slugify";
 
 interface ContagensTableProps {
   data: ContagemData[];
@@ -50,12 +51,14 @@ export function CountsTable({ data }: ContagensTableProps) {
         Header: "Nome",
         accessor: "name",
         Cell: ({ row }: any) => {
-          // Generate slug from ID and name if slug doesn't exist
-          const slug = row.original.id || `${row.original.id}`;
+          const slug = row.original.date
+            ? contagemSlug(row.original.date, row.original.name)
+            : String(row.original.id);
           return (
             <Link
               className="text-ameciclo hover:underline"
-              to={`/dados/contagens/${slug}`}
+              to="/dados/contagens/$slug"
+              params={{ slug }}
             >
               {row.original.name}
             </Link>

--- a/app/components/Contagens/PointDetailsModal.tsx
+++ b/app/components/Contagens/PointDetailsModal.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import { pointData } from "typings";
 
 interface PointDetailsModalProps {
@@ -53,6 +54,15 @@ export function PointDetailsModal({ point, onClose }: PointDetailsModalProps) {
                 <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">Observações</div>
                 <div className="text-sm text-gray-700">{point.popup.obs}</div>
               </div>
+            )}
+
+            {point.popup?.url && (
+              <Link
+                to={point.popup.url}
+                className="block w-full text-center bg-teal-600 hover:bg-teal-700 text-white font-semibold py-2 rounded-lg transition-colors"
+              >
+                Ver mais
+              </Link>
             )}
           </div>
         </div>

--- a/app/hooks/useCountsMapData.ts
+++ b/app/hooks/useCountsMapData.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { pointData, PcrCounting } from "typings";
 import { IntlDateStr } from "~/services/utils";
+import { contagemSlug } from "~/utils/slugify";
 
 const calculateMarkerSize = (totalCyclists: number) => {
   if (totalCyclists === 0) return 8;
@@ -48,7 +49,7 @@ export function useCountsMapData(amecicloData: any[], pcrCounts: PcrCounting[]) 
             name: ponto.name || "Contagem Ameciclo",
             total: totalCyclists,
             date: latestCount?.date ? IntlDateStr(latestCount.date) : "Sem data",
-            url: `/dados/contagens/${ponto.id}`,
+            url: latestCount?.date ? `/dados/contagens/${contagemSlug(latestCount.date, ponto.name || '')}` : `/dados/contagens/${ponto.id}`,
             obs: "As nossas contagens são registradas manualmente através da observação das pessoas voluntárias, registrando a direção do deslocamento e fatores qualitativos.",
           },
           size: calculateMarkerSize(totalCyclists),

--- a/app/queries/dados.contagens.$slug.ts
+++ b/app/queries/dados.contagens.$slug.ts
@@ -1,0 +1,96 @@
+import { queryOptions } from "@tanstack/react-query";
+import { createServerFn } from "@tanstack/react-start";
+import {
+  COUNTINGS_ATLAS_LOCATION,
+  COUNTINGS_ATLAS_LOCATIONS,
+  COUNTINGS_PAGE_DATA,
+} from "~/servers";
+import { cmsFetch } from "~/services/cmsFetch";
+import { contagemSlug } from "~/utils/slugify";
+
+const fetchContagemSlug = createServerFn()
+  .inputValidator((input: { slug: string }) => input)
+  .handler(async ({ data }) => {
+    const fetchLocationData = async (locationId: string, countId?: string) => {
+      const URL = COUNTINGS_ATLAS_LOCATION(locationId);
+      try {
+        const d = await cmsFetch<any>(URL, { ttl: 60, timeout: 5000 });
+        if (!d) return null;
+
+        if (countId && d.counts) {
+          const specificCount = d.counts.find(
+            (c: any) => c.id.toString() === countId
+          );
+          if (specificCount) {
+            return { ...d, selectedCount: specificCount };
+          }
+        }
+
+        if (d.counts && d.counts.length > 0) {
+          return { ...d, selectedCount: d.counts[0] };
+        }
+
+        return d;
+      } catch (error) {
+        console.error("Error fetching location data:", error);
+        return null;
+      }
+    };
+
+    const fetchPageData = async () => {
+      try {
+        const [pageDataRes, locationsRes] = await Promise.all([
+          cmsFetch<any>(COUNTINGS_PAGE_DATA, { ttl: 300, timeout: 5000 }),
+          cmsFetch<any>(COUNTINGS_ATLAS_LOCATIONS, {
+            ttl: 300,
+            timeout: 5000,
+            fallback: [],
+          }),
+        ]);
+
+        return {
+          pageCover: pageDataRes?.data || null,
+          otherCounts: locationsRes || [],
+        };
+      } catch (error) {
+        console.error("Error fetching page data:", error);
+        return { pageCover: null, otherCounts: [] };
+      }
+    };
+
+    const isNumeric = /^\d+$/.test(data.slug);
+
+    if (isNumeric) {
+      const [locationData, pageData] = await Promise.all([
+        fetchLocationData(data.slug),
+        fetchPageData(),
+      ]);
+      return { data: locationData, pageData };
+    }
+
+    // Slug textual: buscar todas as locations e encontrar match
+    const pageData = await fetchPageData();
+    const locations: any[] = pageData.otherCounts || [];
+
+    for (const loc of locations) {
+      if (loc.counts && Array.isArray(loc.counts)) {
+        for (const count of loc.counts) {
+          if (contagemSlug(count.date, loc.name) === data.slug) {
+            const locationData = await fetchLocationData(
+              loc.id.toString(),
+              count.id.toString()
+            );
+            return { data: locationData, pageData };
+          }
+        }
+      }
+    }
+
+    return { data: null, pageData };
+  });
+
+export const contagemSlugQueryOptions = (slug: string) =>
+  queryOptions({
+    queryKey: ["dados", "contagens", slug],
+    queryFn: () => fetchContagemSlug({ data: { slug } }),
+  });

--- a/app/routes/dados.contagens.$slug._index.tsx
+++ b/app/routes/dados.contagens.$slug._index.tsx
@@ -13,6 +13,7 @@ import {
   getCountingStatistics,
   transformOtherCountsForComparison,
 } from "~/services/counting-details.service";
+import { contagemSlug } from "~/utils/slugify";
 
 export { loader };
 
@@ -115,11 +116,14 @@ const Contagem = () => {
                 <Await resolve={Promise.all([dataPromise, pageDataPromise])}>
                     {([data, pageData]) => {
                         if (!data) return null;
-                        const allCounts = transformOtherCountsForComparison(pageData.otherCounts || [], data.id);
+                        const allCounts = transformOtherCountsForComparison(pageData.otherCounts || [], data.id, data.selectedCount?.id);
+                        const currentSlug = data.selectedCount?.date
+                            ? contagemSlug(data.selectedCount.date, data.name)
+                            : data.id.toString();
                         return (
                             <CountingComparisionTable
                                 data={allCounts}
-                                firstSlug={data.id.toString()}
+                                firstSlug={currentSlug}
                             />
                         );
                     }}

--- a/app/routes/dados.contagens.$slug.compare.$compareSlug.tsx
+++ b/app/routes/dados.contagens.$slug.compare.$compareSlug.tsx
@@ -12,6 +12,8 @@ import Breadcrumb from "~/components/Commom/Breadcrumb";
 import { colors } from "~/components/Charts/FlowChart/FlowContainer";
 import { VerticalStatisticsBoxes } from "~/components/Contagens/VerticalStatisticsBoxes";
 import { Tooltip } from "~/components/Commom/Tooltip";
+import { contagemSlug } from "~/utils/slugify";
+import { IntlDateStr } from "~/services/utils";
 
 interface Series {
   name: string | undefined;
@@ -68,7 +70,11 @@ function getPointsDataForComparingCounting(data: any[]) {
     const lng = parseFloat(location.longitude);
     
     if (isNaN(lat) || isNaN(lng)) return null;
-    
+
+    const slug = count.date
+      ? contagemSlug(count.date, location.name)
+      : String(location.id);
+
     return {
       key: location.name,
       latitude: lat,
@@ -77,8 +83,8 @@ function getPointsDataForComparingCounting(data: any[]) {
       popup: {
         name: location.name,
         total: count.total_cyclists || 0,
-        date: new Intl.DateTimeFormat("pt-BR").format(new Date(count.date)),
-        url: `/dados/contagens/${location.id}`,
+        date: count.date ? IntlDateStr(count.date) : '',
+        url: `/dados/contagens/${slug}`,
         obs: ""
       },
       size: Math.round((count.total_cyclists || 0) / 250) + 15,
@@ -128,14 +134,19 @@ export default function Compare() {
                         <path d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z" />
                       </svg>
                     </li>
-                    {data.map((location: any, index: number) => (
-                      <li key={index} className="flex items-center">
-                        <Link to={`/dados/contagens/${location?.id || ''}`} className="text-white">{location?.name || 'Contagem'}</Link>
-                        <svg className="fill-current w-3 h-3 mx-3" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
-                          <path d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z" />
-                        </svg>
-                      </li>
-                    ))}
+                    {data.map((location: any, index: number) => {
+                      const locationSlug = location?.selectedCount?.date
+                        ? contagemSlug(location.selectedCount.date, location.name)
+                        : String(location?.id || '');
+                      return (
+                        <li key={index} className="flex items-center">
+                          <Link to={`/dados/contagens/${locationSlug}`} className="text-white">{location?.name || 'Contagem'}</Link>
+                          <svg className="fill-current w-3 h-3 mx-3" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
+                            <path d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z" />
+                          </svg>
+                        </li>
+                      );
+                    })}
                     <li className="flex items-center">
                       <span>Comparação</span>
                     </li>
@@ -166,7 +177,7 @@ export default function Compare() {
               text: index === 0 ? 'text-teal-700' : 'text-emerald-700',
               accent: index === 0 ? 'bg-teal-500' : 'bg-emerald-500'
             };
-            
+
                     return (
                       <div key={index} className={`${colors.bg} ${colors.border} border-2 rounded-lg p-6 shadow-lg`}>
                         <div className="flex items-center justify-between mb-4">
@@ -174,7 +185,7 @@ export default function Compare() {
                             <div className={`w-4 h-4 ${colors.accent} rounded-full`}></div>
                             <span className="text-sm font-medium text-gray-600">{data[index]?.name || `Ponto ${index + 1}`}</span>
                           </div>
-                          <span className="text-sm text-gray-500">{box.date}</span>
+                          <span className="text-sm text-gray-500">{box.date ? IntlDateStr(box.date) : ''}</span>
                         </div>
                         
                         <h2 className={`text-2xl font-bold ${colors.text} mb-6`}>{box.title}</h2>
@@ -295,12 +306,19 @@ export default function Compare() {
                           )}
                           
                           <div className="pt-4">
-                            <Link 
-                              to={`/dados/contagens/${data[index]?.slug}`}
-                              className={`inline-block w-full text-center py-3 px-4 ${colors.accent} text-white rounded-md hover:opacity-90 transition-opacity font-medium`}
-                            >
-                              Ver Detalhes Completos
-                            </Link>
+                            {(() => {
+                              const detailSlug = data[index]?.selectedCount?.date
+                                ? contagemSlug(data[index].selectedCount.date, data[index].name)
+                                : String(data[index]?.id);
+                              return (
+                                <Link 
+                                  to={`/dados/contagens/${detailSlug}`}
+                                  className={`inline-block w-full text-center py-3 px-4 ${colors.accent} text-white rounded-md hover:opacity-90 transition-opacity font-medium`}
+                                >
+                                  Ver Detalhes Completos
+                                </Link>
+                              );
+                            })()}
                           </div>
                         </div>
                       </div>
@@ -351,11 +369,23 @@ export default function Compare() {
           <Await resolve={Promise.all([dataPromise, pageDataPromise, Promise.resolve(toCompare)])}>
             {([data, pageData, compareIds]) => {
               const excludeIds = data.map((d: any) => d?.id).filter(Boolean);
-              const filteredData = pageData.otherCounts.filter((d: any) => !excludeIds.includes(d.id));
+              const flatData = (pageData.otherCounts || [])
+                .filter((loc: any) => !excludeIds.includes(loc.id))
+                .flatMap((loc: any) =>
+                  (loc.counts || []).map((count: any) => ({
+                    id: loc.id,
+                    name: loc.name,
+                    date: count.date,
+                    total_cyclists: count.total_cyclists,
+                  }))
+                );
+              const currentSlug = data[0]?.selectedCount?.date
+                ? contagemSlug(data[0].selectedCount.date, data[0].name)
+                : compareIds[0];
               return (
                 <CountingComparisionTable
-                  data={filteredData}
-                  firstSlug={compareIds[0]}
+                  data={flatData}
+                  firstSlug={currentSlug}
                 />
               );
             }}

--- a/app/services/counting-details.service.ts
+++ b/app/services/counting-details.service.ts
@@ -66,16 +66,16 @@ export function getCountingStatistics(location: any, count: any) {
   ];
 }
 
-export function transformOtherCountsForComparison(otherCounts: any[], currentLocationId: number) {
+export function transformOtherCountsForComparison(otherCounts: any[], currentLocationId: number, currentCountId?: number) {
   return (otherCounts || [])
-    .filter((loc: any) => loc.id !== currentLocationId)
     .flatMap((loc: any) =>
       (loc.counts || []).map((count: any) => ({
         id: loc.id,
         name: loc.name,
-        slug: loc.id.toString(),
         date: count.date,
+        countId: count.id,
         total_cyclists: count.total_cyclists,
       }))
-    );
+    )
+    .filter((row: any) => !(row.id === currentLocationId && row.countId === currentCountId));
 }

--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -13,7 +13,17 @@ export const IntlPercentil = (n: number): string => {
 };
 
 export const IntlDateStr = (str: string): string => {
+  if (!str) return '';
+  const parts = str.slice(0, 10).split('-');
+  if (parts.length === 3) {
+    const [year, month, day] = parts.map(Number);
+    if (!isNaN(year) && !isNaN(month) && !isNaN(day)) {
+      return new Intl.DateTimeFormat("pt-BR").format(new Date(year, month - 1, day));
+    }
+  }
+  // Fallback para formatos não-YYYY-MM-DD
   const date = new Date(str);
+  if (isNaN(date.getTime())) return str;
   return new Intl.DateTimeFormat("pt-BR").format(date);
 };
 

--- a/app/utils/slugify.ts
+++ b/app/utils/slugify.ts
@@ -15,3 +15,19 @@ export function unslugify(slug: string): string {
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
 }
+
+/**
+ * Gera slug de contagem no formato: aaaa_mm_dd-nome_da_contagem
+ * Ex: "2022-03-30" + "Av. Rui Barbosa x R. Amélia" → "2022_03_30-av_rui_barbosa_x_r_amelia"
+ */
+export function contagemSlug(date: string, name: string): string {
+  const datePart = date.slice(0, 10).replace(/-/g, '_');
+  const namePart = name
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s]/g, '')
+    .trim()
+    .replace(/\s+/g, '_');
+  return `${datePart}-${namePart}`;
+}


### PR DESCRIPTION
## Resumo

Melhorias na experiência de navegação e correções nas páginas de contagens de ciclistas.

## Mudanças

### 🐛 Correções

- **Fix timezone em datas**: `IntlDateStr` agora parseia datas `YYYY-MM-DD` como horário local, corrigindo bug onde o fuso UTC-3 de Recife deslocava a data um dia para trás (ex: 30/03 aparecia como 29/03). Também adicionado tratamento para valores nulos e formatos inesperados, evitando crash "Invalid time value".

### ✨ Funcionalidades

- **Slugs textuais para contagens**: URLs das contagens agora usam o formato `aaaa_mm_dd-nome_da_contagem` (ex: `2022_03_30-av_rui_barbosa_x_r_amelia`) em vez de IDs numéricos. Aplicado em:
  - Links no mapa (modal e pontos)
  - Tabela de contagens
  - Página de comparação (rota, breadcrumb, botões)
  - Backward compatible: IDs numéricos antigos continuam funcionando

- **Botão "Ver mais" no modal**: Ao clicar em um ponto de contagem no mapa, o modal agora exibe um botão "Ver mais" que leva à página individual da contagem (apenas para contagens da Ameciclo que possuem página).

- **Comparação entre contagens do mesmo local**: Agora é possível comparar contagens de datas diferentes no mesmo ponto (ex: Av. Rui Barbosa 2013 vs 2022). Antes, todas as contagens do mesmo local eram excluídas da tabela de comparação.

## Arquivos modificados

| Arquivo | Mudança |
|---------|---------|
| `app/services/utils.ts` | Fix timezone + robustez no IntlDateStr |
| `app/utils/slugify.ts` | Nova função `contagemSlug` |
| `app/components/Contagens/PointDetailsModal.tsx` | Botão "Ver mais" |
| `app/hooks/useCountsMapData.ts` | Slugs textuais nos pontos do mapa |
| `app/components/Contagens/CountsTable.tsx` | Slugs textuais na tabela |
| `app/queries/dados.contagens.$slug.ts` | Resolução de slugs textuais |
| `app/services/counting-details.service.ts` | Filtro por countId específico |
| `app/routes/dados.contagens.$slug.index.tsx` | firstSlug textual + countId |
| `app/queries/dados.contagens.$slug.compare.$compareSlug.ts` | Resolução de slugs + countId na comparação |
| `app/routes/dados.contagens.$slug.compare.$compareSlug.tsx` | Slugs textuais + datas formatadas |
| `app/components/Contagens/CountingComparisionTable.tsx` | Slugs textuais nos links |

## Testado

- Build de produção passa sem erros novos
- Datas exibidas corretamente no formato dd/mm/aaaa
- Backward compatibility com IDs numéricos nas URLs