### PR TITLE
ci: add GitHub Actions workflows (validate, deploy, PR previews)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: production
+      url: https://ameciclo.org
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+        with:
+          cache: true
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          packageManager: pnpm
+          command: deploy

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,73 @@
+name: PR Preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Deploy Preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+        with:
+          cache: true
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Upload preview version to Cloudflare
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -o pipefail
+          output=$(pnpm exec wrangler versions upload \
+            --message "PR #${{ github.event.pull_request.number }} @ ${{ github.event.pull_request.head.sha }}" \
+            --tag "pr-${{ github.event.pull_request.number }}" \
+            --preview-alias "pr-${{ github.event.pull_request.number }}" 2>&1 | tee /dev/stderr)
+          preview_url=$(printf '%s\n' "$output" | grep -oE 'https://[a-z0-9.-]+\.workers\.dev' | head -1)
+          version_id=$(printf '%s\n' "$output" | grep -oE 'Worker Version ID:[[:space:]]*[a-f0-9-]+' | awk '{print $NF}')
+          {
+            echo "preview-url=${preview_url}"
+            echo "version-id=${version_id}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            ### 🚀 Preview deploy
+
+            | | |
+            | --- | --- |
+            | **URL** | ${{ steps.deploy.outputs.preview-url || '_extraction failed — check workflow logs_' }} |
+            | **Version** | `${{ steps.deploy.outputs.version-id || 'n/a' }}` |
+            | **Commit** | `${{ github.event.pull_request.head.sha }}` |
+
+            Updates on every push. Production is unchanged.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,90 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: pr-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+        with:
+          cache: true
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+  typecheck:
+    name: Typecheck (informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+        with:
+          cache: true
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm typecheck
+
+  lint:
+    name: Lint (informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+        with:
+          cache: true
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint


### PR DESCRIPTION
## Summary

Introduce CI/CD on GitHub Actions, replacing the current manual `pnpm deploy` flow. Three workflows:

- **`pr-validation.yml`** — runs on every PR to `main`.
  - `build` job is **required** (blocks merge if `pnpm build` fails).
  - `typecheck` and `lint` are **informational** (`continue-on-error: true`) because the repo has ~299 pre-existing TS errors and ~1k pre-existing ESLint errors. Plan: fix those in a follow-up pass, then promote both to required checks via branch protection.
- **`deploy.yml`** — production deploy on push to `main` (or manual `workflow_dispatch`).
  - Uses `cloudflare/wrangler-action@v3` with a `production` GitHub Environment so deploys are visible/auditable in the Deployments tab.
  - `concurrency: deploy-production` with `cancel-in-progress: false` so a quick second push doesn't kill an in-flight deploy.
- **`pr-preview.yml`** — per-PR preview deploy via `wrangler versions upload --preview-alias pr-<N>`.
  - Stable URL per PR (alias survives across pushes).
  - Sticky comment (`marocchino/sticky-pull-request-comment`) updated in place rather than spamming on every push.
  - Skipped on fork PRs (`if: head.repo.full_name == github.repository`) since secrets aren't exposed to forked workflow runs.

All three pin Node and pnpm via `jdx/mise-action@v2` reading `mise.toml` — single source of truth, no drift between local and CI. pnpm store cached per `pnpm-lock.yaml` hash.

## Required setup before merge

- [ ] Add repo secret **`CLOUDFLARE_API_TOKEN`**
  - Cloudflare dashboard → My Profile → API Tokens → Create Token
  - Use the **"Edit Cloudflare Workers"** template (or a custom token with `Account.Workers Scripts: Edit` scoped to the Ameciclo account `8b9af9b81476222e1a787f42f3c8076a`)
- [ ] After this PR's first CI run, add `Build` to the required status checks for `main` in repo Settings → Branches

## What's intentionally not here

- No Husky / lint-staged (per request — main lever is fixing the existing typecheck/lint debt, not pre-commit fences on top of broken code).
- No tests step (no test runner configured in the project yet).
- No `[env.preview]` block in `wrangler.jsonc` — preview Workers reuse production secrets/vars, which is fine for this site's surface.

## Test plan

- [ ] Open this PR → `PR Validation` workflow runs; `Build` is green; `Typecheck (informational)` and `Lint (informational)` show their pre-existing failures without blocking merge
- [ ] After `CLOUDFLARE_API_TOKEN` is added, `PR Preview` workflow runs and posts a comment with a `pr-<N>-ameciclo.*.workers.dev` URL that loads the site
- [ ] Merge to `main` triggers `Deploy to Production`; visible in repo Deployments tab; https://ameciclo.org reflects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)