### PR TITLE
feat(biciclopedia): add @tailwindcss/typography for FAQ answers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 /build
 .env
 .gemini/
+.playwright-cli/
 
 docs
 

--- a/app/routes/biciclopedia_.$question.tsx
+++ b/app/routes/biciclopedia_.$question.tsx
@@ -87,7 +87,7 @@ function QuestionPage() {
           </div>
           <div className="py-10 mt-10 text-center border-t border-gray-300">
             <div className="flex flex-wrap justify-center">
-              <div className="w-full px-4 mb-4 text-lg leading-relaxed text-center text-gray-800 lg:w-9/12 markdown_box">
+              <div className="w-full px-4 mb-4 text-gray-800 lg:w-9/12 markdown_box prose prose-stone max-w-none mx-auto text-left prose-a:text-ameciclo prose-a:underline prose-a:underline-offset-2 hover:prose-a:opacity-80">
                 <ReactMarkdown>{questionData.answer || ''}</ReactMarkdown>
               </div>
             </div>

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.0.0",
     "@rsbuild/core": "^2.0.2",
+    "@tailwindcss/typography": "^0.5.19",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@types/react-map-gl": "^6.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@rsbuild/core':
         specifier: ^2.0.2
         version: 2.0.2
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0))
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.28
@@ -1243,6 +1246,11 @@ packages:
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
   '@tanstack/history@1.161.6':
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
@@ -3065,6 +3073,10 @@ packages:
     peerDependencies:
       postcss: ^8.2.14
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
@@ -4550,6 +4562,11 @@ snapshots:
   '@swc/helpers@0.5.21':
     dependencies:
       tslib: 2.8.1
+
+  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(tsx@4.21.0))':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.19(tsx@4.21.0)
 
   '@tanstack/history@1.161.6': {}
 
@@ -6816,6 +6833,11 @@ snapshots:
     dependencies:
       postcss: 8.5.10
       postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@6.1.2:
     dependencies:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,5 +28,5 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
## Summary

Fix the FAQ answer rendering on \`/biciclopedia/:id\`. Markdown-rendered links were visually indistinguishable from body text (Tailwind preflight strips link underline + color, and the answer container only set \`text-gray-800\`). Lists, headings, code blocks and other markdown elements were also unstyled.

Confirmed the issue with playwright-cli on \`http://localhost:5173/biciclopedia/3\`:

**Before** — links inherit \`color: gray-800\`, \`text-decoration: none\`, look like text:

\`\`\`
Chave Quinze: Trava U-lock e dicas de como prender a bike
Bike é Legal: Trancas e correntes para prender bicicleta. Qual é melhor?
\`\`\`

**After** — links are brand teal, underlined, list bullets visible, body left-aligned.

## What changed

- Add \`@tailwindcss/typography@0.5.19\` and register the plugin in \`tailwind.config.ts\`.
- On the FAQ answer container in \`app/routes/biciclopedia_.\$question.tsx\`, drop \`text-lg leading-relaxed text-center\` and apply:
  \`\`\`
  prose prose-stone max-w-none mx-auto text-left
  prose-a:text-ameciclo prose-a:underline prose-a:underline-offset-2
  hover:prose-a:opacity-80
  \`\`\`
- \`.gitignore\`: add \`.playwright-cli/\` so local CLI screenshot/snapshot artifacts don't pollute \`git status\`.

The title/description block above the divider keeps its existing centered design — only the markdown answer body switches to left-aligned, which reads better for multi-paragraph or list content.

## Why \`prose\` over a custom \`components.a\` override

A per-element override in \`<ReactMarkdown components={{ a: ... }}>\` would only fix links. Prose covers links, lists, headings, blockquotes, code blocks, tables, and \`<hr>\` in one classname change — handles whatever any current or future FAQ author writes.

## Out of scope

- \`app/components/QuemSomos/InfoSection.tsx\` also uses \`ReactMarkdown\` but on a teal background with large white text. Applying prose there would need \`prose-invert\` and re-tuning the text size; left untouched here to keep scope to the page that actually had the bug.
- Not adding \`remark-gfm\` or \`rehype-external-links\` in this PR. Both would still be useful (autolinks for bare URLs, automatic \`target=\"_blank\"\` for external links) but the user-visible bug here was styling, not functionality. Easy follow-up.

## Test plan

- [x] \`pnpm install --frozen-lockfile\` clean
- [x] \`pnpm build\` succeeds (8.41s)
- [x] Visual: \`/biciclopedia/3\` answer body renders with teal underlined links and bulleted list (verified via playwright-cli screenshot)
- [x] PR Preview: spot-check 2–3 other questions with rich answer content (lists, multiple paragraphs)
- [x] Confirm no visual regression on \`/biciclopedia\` index (this PR doesn't touch the index, but worth a glance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)