### PR TITLE
ci: bump action versions ahead of GitHub's Node 24 cutover

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,9 @@ jobs:
       name: production
       url: https://ameciclo.org
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
         with:
           cache: true
 
@@ -32,7 +32,7 @@ jobs:
         id: pnpm-store
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,9 +20,9 @@ jobs:
     timeout-minutes: 15
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
         with:
           cache: true
 
@@ -30,7 +30,7 @@ jobs:
         id: pnpm-store
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -58,7 +58,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Comment preview URL on PR
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: pr-preview
           message: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
         with:
           cache: true
 
@@ -27,7 +27,7 @@ jobs:
         id: pnpm-store
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -43,9 +43,9 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
         with:
           cache: true
 
@@ -53,7 +53,7 @@ jobs:
         id: pnpm-store
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -69,9 +69,9 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
         with:
           cache: true
 
@@ -79,7 +79,7 @@ jobs:
         id: pnpm-store
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,17 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "ameciclo",
   "account_id": "8b9af9b81476222e1a787f42f3c8076a",
+  /**
+   * `workers_dev: true` exposes the Worker on
+   * <name>.<account-subdomain>.workers.dev (ameciclo.ti-8b9.workers.dev).
+   * `preview_urls: true` lets `wrangler versions upload --preview-alias`
+   * produce per-version URLs like pr-<N>-ameciclo.ti-8b9.workers.dev,
+   * which the PR Preview workflow surfaces as a sticky comment.
+   *
+   * Production traffic still goes to the custom domains in `routes`.
+   */
+  "workers_dev": true,
+  "preview_urls": true,
   "routes": [
     { "pattern": "ameciclo.org", "custom_domain": true },
     { "pattern": "www.ameciclo.org", "custom_domain": true },


### PR DESCRIPTION
## Summary

Two related CI hardening changes:

### 1. Bump action versions ahead of GitHub's Node 24 cutover

GitHub is forcing the Node 24 runtime for all Actions starting **June 2, 2026**. Bumping the actions we use to versions that already run on Node 24, so the workflows stop emitting deprecation warnings now and don't break on the cutover.

| Action | Old | New | Why |
| --- | --- | --- | --- |
| \`actions/checkout\` | v4 | **v6** | Node 24 runtime |
| \`actions/cache\` | v4 | **v5** | Node 24 runtime |
| \`jdx/mise-action\` | v2 | **v4** | Node 24 runtime; v3 also adds env-var export from \`mise.toml\` as a side benefit (we don't currently use it) |
| \`marocchino/sticky-pull-request-comment\` | v2 | **v3** | Node 24 runtime — confirmed via [v3.0.0 release notes](https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.0): just \"Update node to 24, Update deps\" |
| \`cloudflare/wrangler-action\` | v3 | (unchanged) | \`@v3\` auto-resolves to v3.15.0 (latest); there's no v4 |

All bumps are runtime-only majors per the upstream changelogs — no API shape changes affecting how we call these actions.

### 2. Declare \`workers_dev\` + \`preview_urls\` in \`wrangler.jsonc\`

The Cloudflare account's workers.dev subdomain was just enabled in the dashboard (\`*-ameciclo.ti-8b9.workers.dev\`), which is what made the PR Preview workflow able to surface real preview URLs. Without making this declarative, the next \`wrangler deploy\` could flip the dashboard toggle back to disabled and silently break the preview workflow again.

- \`workers_dev: true\` keeps the Worker exposed on the account subdomain. Production traffic still goes through the custom-domain routes for \`ameciclo.org\` / \`www.ameciclo.org\`.
- \`preview_urls: true\` lets \`wrangler versions upload --preview-alias\` generate the per-PR \`pr-<N>-ameciclo.ti-8b9.workers.dev\` URL that the workflow's sticky comment links to.

Verified locally with \`wrangler deploy --dry-run\`: schema-valid, no warnings.

## Test plan

- [ ] PR Validation \`Build\` job runs green on this PR
- [ ] PR Preview job produces a working \`pr-147-ameciclo.ti-8b9.workers.dev\` URL (verifies the bumped \`sticky-pull-request-comment@v3\` still posts correctly AND that the wrangler config still produces preview URLs)
- [ ] After merge, the next deploy to \`main\` succeeds without flipping the dashboard toggle off

🤖 Generated with [Claude Code](https://claude.com/claude-code)