### PR TITLE
chore(queries): narrow id schema to z.number() in home & projetos

### DIFF
--- a/app/queries/home.ts
+++ b/app/queries/home.ts
@@ -14,7 +14,7 @@ const HomeSchema = z.object({
 });
 
 const ProjectSchema = z.object({
-  id: z.union([z.string(), z.number()]),
+  id: z.number(),
   documentId: z.string().nullish(),
   name: z.string().nullish(),
   description: z.string().nullish(),

--- a/app/queries/projetos.ts
+++ b/app/queries/projetos.ts
@@ -5,25 +5,25 @@ import { z } from "zod";
 import { strapiClient } from "~/lib/strapi";
 
 const MediaSchema = z.object({
-  id: z.union([z.string(), z.number()]).nullish(),
+  id: z.number().nullish(),
   url: z.string().nullish(),
   caption: z.string().nullish(),
 });
 
 const WorkgroupSchema = z.object({
-  id: z.union([z.string(), z.number()]),
+  id: z.number(),
   documentId: z.string().nullish(),
   name: z.string().nullish(),
 });
 
 const LinkEntrySchema = z.object({
-  id: z.union([z.string(), z.number()]),
+  id: z.number(),
   title: z.string().nullish(),
   link: z.string().nullish(),
 });
 
 const StepEntrySchema = z.object({
-  id: z.union([z.string(), z.number()]),
+  id: z.number(),
   title: z.string().nullish(),
   description: z.string().nullish(),
   link: z.string().nullish(),
@@ -31,7 +31,7 @@ const StepEntrySchema = z.object({
 });
 
 const ProductEntrySchema = z.object({
-  id: z.union([z.string(), z.number()]),
+  id: z.number(),
   title: z.string().nullish(),
   name: z.string().nullish(),
   description: z.string().nullish(),
@@ -39,14 +39,14 @@ const ProductEntrySchema = z.object({
 });
 
 const PartnerSchema = z.object({
-  id: z.union([z.string(), z.number()]),
+  id: z.number(),
   documentId: z.string().nullish(),
   name: z.string().nullish(),
   logo: z.array(MediaSchema).nullish(),
 });
 
 const ProjectListSchema = z.object({
-  id: z.union([z.string(), z.number()]),
+  id: z.number(),
   documentId: z.string().nullish(),
   name: z.string().nullish(),
   slug: z.string().nullish(),


### PR DESCRIPTION
## Summary

Retroactively apply the schema-honesty lesson from PR #144 to the previously-merged migrations. The original PRs (#134 home, #135 projetos) used \`z.union([z.string(), z.number()])\` for \`id\` defensively because the OpenAPI spec at \`app/types/strapi-api.ts\` declares \`id: string | number\`. But Strapi v5's runtime contract is \`id: number\`, full stop — verified by hitting the actual API across \`faqs\`, \`faq-tags\`, \`projects\`, \`workgroups\`, \`home\`, and through nested relations. The spec is auto-generated and over-permissive; runtime is consistent.

The defensive union forces consumers either to widen their own types to accept strings or to reach for \`Number()\` coercion at use sites — both fight the type system instead of stating the truth.

## What changed

- \`app/queries/home.ts\`: \`ProjectSchema.id\` → \`z.number()\`
- \`app/queries/projetos.ts\`: every \`id\` field → \`z.number()\` (preserve \`.nullish()\` on \`MediaSchema\` where the field was already optional)

## Why this is safe

\`grep -rn \".id\" app/components/PaginaInicial/ app/components/Projetos/ app/routes/projetos.\$projeto.tsx\` shows \`.id\` is only used as React keys (\`key={project.id}\`) and with optional chaining (\`photo.id ?? index\`). No consumer relies on string-side behavior.

## Test plan

- [x] \`pnpm install --frozen-lockfile\` clean
- [x] \`pnpm build\` succeeds (8.24s)
- [x] \`pnpm typecheck\` reports the same 300 pre-existing errors as main — no new errors introduced
- [ ] PR Preview: home carousel still renders projects, \`/projetos\` lists, \`/projetos/<slug>\` detail still loads with gallery + steps + partners

## What's intentionally not in scope

- Not touching biciclopedia (#144 already uses \`z.number()\` post-rebase).
- Not adding a \`.transform(Number)\` — that was a half-step. Honest schema beats defensive transform when runtime is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)