### PR TITLE
feat(admin): scaffold admin area with contagens table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 .env
 .gemini/
 .playwright-cli/
+.tanstack/
 
 docs
 

--- a/app/components/Admin/AdminSidebar.tsx
+++ b/app/components/Admin/AdminSidebar.tsx
@@ -1,0 +1,55 @@
+import { Link, useRouterState } from "@tanstack/react-router";
+import { LayoutDashboard, Users2 } from "lucide-react";
+import { cn } from "~/lib/utils";
+
+type NavItem = {
+  to: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  exact?: boolean;
+};
+
+const NAV: NavItem[] = [
+  { to: "/admin", label: "Dashboard", icon: LayoutDashboard, exact: true },
+  { to: "/admin/contagens", label: "Contagens", icon: Users2 },
+];
+
+export function AdminSidebar() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  return (
+    <aside className="hidden lg:flex w-60 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
+      <div className="px-6 py-5 border-b">
+        <Link to="/admin" className="flex items-baseline gap-2">
+          <span className="text-lg font-semibold tracking-tight">Ameciclo</span>
+          <span className="text-xs uppercase tracking-wider text-muted-foreground">Admin</span>
+        </Link>
+      </div>
+      <nav className="flex-1 px-3 py-4 space-y-1">
+        {NAV.map(({ to, label, icon: Icon, exact }) => {
+          const active = exact ? pathname === to : pathname === to || pathname.startsWith(`${to}/`);
+          return (
+            <Link
+              key={to}
+              to={to}
+              className={cn(
+                "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                active
+                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                  : "text-sidebar-foreground/80 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground",
+              )}
+            >
+              <Icon className="size-4 shrink-0" />
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="border-t px-6 py-4 text-xs text-muted-foreground">
+        <Link to="/" className="hover:text-foreground transition-colors">
+          ← Voltar ao site
+        </Link>
+      </div>
+    </aside>
+  );
+}

--- a/app/components/Admin/AdminTopbar.tsx
+++ b/app/components/Admin/AdminTopbar.tsx
@@ -1,0 +1,19 @@
+type AdminTopbarProps = {
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+};
+
+export function AdminTopbar({ title, description, actions }: AdminTopbarProps) {
+  return (
+    <header className="flex flex-wrap items-start justify-between gap-4 border-b bg-background/80 backdrop-blur-sm px-6 py-4">
+      <div className="min-w-0">
+        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+        {description && (
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </header>
+  );
+}

--- a/app/components/Admin/ContagensTable.tsx
+++ b/app/components/Admin/ContagensTable.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { Search, Pencil } from "lucide-react";
+import { Input } from "~/components/ui/input";
+import { Button } from "~/components/ui/button";
+import { Badge } from "~/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+
+export type ContagemRow = {
+  id: number | string;
+  name: string;
+  slug: string;
+  date: string;
+  total_cyclists: number;
+};
+
+type SortKey = "name" | "date" | "total_cyclists";
+type SortDir = "asc" | "desc";
+
+const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+function formatDate(value: string): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return dateFormatter.format(d);
+}
+
+export function ContagensTable({ rows }: { rows: ContagemRow[] }) {
+  const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("date");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const base = q ? rows.filter((r) => r.name.toLowerCase().includes(q)) : rows;
+    const sorted = [...base].sort((a, b) => {
+      const av = a[sortKey];
+      const bv = b[sortKey];
+      if (typeof av === "number" && typeof bv === "number") return av - bv;
+      return String(av).localeCompare(String(bv));
+    });
+    return sortDir === "desc" ? sorted.reverse() : sorted;
+  }, [rows, query, sortKey, sortDir]);
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir(key === "name" ? "asc" : "desc");
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="relative max-w-sm flex-1">
+          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Buscar por nome do ponto..."
+            className="pl-9"
+          />
+        </div>
+        <Badge variant="secondary" className="text-xs">
+          {filtered.length.toLocaleString("pt-BR")} de{" "}
+          {rows.length.toLocaleString("pt-BR")}
+        </Badge>
+      </div>
+
+      <div className="rounded-md border bg-background">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <SortableHead label="Ponto" active={sortKey === "name"} dir={sortDir} onClick={() => toggleSort("name")} />
+              <SortableHead label="Data" active={sortKey === "date"} dir={sortDir} onClick={() => toggleSort("date")} />
+              <SortableHead label="Ciclistas" align="right" active={sortKey === "total_cyclists"} dir={sortDir} onClick={() => toggleSort("total_cyclists")} />
+              <TableHead className="w-32 text-right">Ações</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-center text-sm text-muted-foreground py-12">
+                  Nenhum ponto corresponde à busca.
+                </TableCell>
+              </TableRow>
+            ) : (
+              filtered.map((row, idx) => (
+                <TableRow key={`${row.id}-${row.date}-${idx}`}>
+                  <TableCell className="font-medium">{row.name}</TableCell>
+                  <TableCell>{formatDate(row.date)}</TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {row.total_cyclists.toLocaleString("pt-BR")}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button asChild size="sm" variant="ghost">
+                      <Link to="/dados/contagens/$slug" params={{ slug: row.slug }}>
+                        <Pencil className="size-4" />
+                        Editar
+                      </Link>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+function SortableHead({
+  label,
+  active,
+  dir,
+  onClick,
+  align = "left",
+}: {
+  label: string;
+  active: boolean;
+  dir: SortDir;
+  onClick: () => void;
+  align?: "left" | "right";
+}) {
+  return (
+    <TableHead className={align === "right" ? "text-right" : undefined}>
+      <button
+        type="button"
+        onClick={onClick}
+        className="inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {label}
+        {active && <span aria-hidden>{dir === "asc" ? "▲" : "▼"}</span>}
+      </button>
+    </TableHead>
+  );
+}

--- a/app/components/Commom/MainContent.tsx
+++ b/app/components/Commom/MainContent.tsx
@@ -6,10 +6,12 @@ interface MainContentProps {
 
 export function MainContent({ children }: MainContentProps) {
   const location = useRouterState({ select: (s) => s.location });
-  const isCicloDadosPage = location.pathname === '/dados/ciclodados';
-  
+  const path = location.pathname;
+  const isFullBleed =
+    path === '/dados/ciclodados' || path === '/admin' || path.startsWith('/admin/');
+
   return (
-    <main className={isCicloDadosPage ? '' : 'pt-14'}>
+    <main className={isFullBleed ? '' : 'pt-14'}>
       {children}
     </main>
   );

--- a/app/components/ui/badge.tsx
+++ b/app/components/ui/badge.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "~/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/app/components/ui/card.tsx
+++ b/app/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "~/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "~/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/app/components/ui/separator.tsx
+++ b/app/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "~/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/app/components/ui/table.tsx
+++ b/app/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "~/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -132,24 +132,23 @@ function NotFoundComponent() {
   );
 }
 
+function shouldHidePublicChrome(pathname: string): boolean {
+  // Routes that bring their own chrome and shouldn't render the public Navbar/Footer.
+  return (
+    pathname === "/dados/ciclodados" ||
+    pathname === "/admin" ||
+    pathname.startsWith("/admin/")
+  );
+}
+
 function ConditionalNavbar() {
   const location = useRouterState({ select: (s) => s.location });
-  const isCicloDadosPage = location.pathname === "/dados/ciclodados";
-
-  if (isCicloDadosPage) {
-    return null;
-  }
-
+  if (shouldHidePublicChrome(location.pathname)) return null;
   return <Navbar />;
 }
 
 function ConditionalFooter() {
   const location = useRouterState({ select: (s) => s.location });
-  const isCicloDadosPage = location.pathname === "/dados/ciclodados";
-
-  if (isCicloDadosPage) {
-    return null;
-  }
-
+  if (shouldHidePublicChrome(location.pathname)) return null;
   return <Footer />;
 }

--- a/app/routes/admin.contagens.index.tsx
+++ b/app/routes/admin.contagens.index.tsx
@@ -1,0 +1,49 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { AdminTopbar } from "~/components/Admin/AdminTopbar";
+import { ContagensTable, type ContagemRow } from "~/components/Admin/ContagensTable";
+import { Button } from "~/components/ui/button";
+import { Plus } from "lucide-react";
+import { contagensQueryOptions } from "~/queries/dados.contagens";
+import { RouteLoading, RouteErrorBoundary } from "~/components/Commom/RouteBoundaries";
+import { seo } from "~/utils/seo";
+
+export const Route = createFileRoute("/admin/contagens/")({
+  loader: ({ context: { queryClient } }) =>
+    queryClient.ensureQueryData(contagensQueryOptions()),
+  head: () =>
+    seo({
+      title: "Admin · Contagens - Ameciclo",
+      description: "Gestão das contagens de ciclistas registradas pela Ameciclo.",
+      pathname: "/admin/contagens",
+      noindex: true,
+    }),
+  component: AdminContagens,
+  pendingComponent: () => <RouteLoading label="Carregando contagens..." />,
+  pendingMs: 500,
+  pendingMinMs: 800,
+  errorComponent: RouteErrorBoundary,
+});
+
+function AdminContagens() {
+  const { data: { summaryData } } = useSuspenseQuery(contagensQueryOptions());
+  const rows = summaryData.countsData as ContagemRow[];
+
+  return (
+    <>
+      <AdminTopbar
+        title="Contagens"
+        description="Gestão das contagens de ciclistas registradas pela Ameciclo."
+        actions={
+          <Button size="sm" disabled>
+            <Plus className="size-4" />
+            Nova contagem
+          </Button>
+        }
+      />
+      <div className="flex-1 px-6 py-6">
+        <ContagensTable rows={rows} />
+      </div>
+    </>
+  );
+}

--- a/app/routes/admin.index.tsx
+++ b/app/routes/admin.index.tsx
@@ -1,0 +1,73 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Users2, ArrowRight } from "lucide-react";
+import { AdminTopbar } from "~/components/Admin/AdminTopbar";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Button } from "~/components/ui/button";
+import { contagensQueryOptions } from "~/queries/dados.contagens";
+import { RouteLoading, RouteErrorBoundary } from "~/components/Commom/RouteBoundaries";
+
+export const Route = createFileRoute("/admin/")({
+  loader: ({ context: { queryClient } }) =>
+    queryClient.ensureQueryData(contagensQueryOptions()),
+  component: AdminDashboard,
+  pendingComponent: () => <RouteLoading label="Carregando admin..." />,
+  pendingMs: 500,
+  pendingMinMs: 800,
+  errorComponent: RouteErrorBoundary,
+});
+
+function AdminDashboard() {
+  const { data: { summaryData } } = useSuspenseQuery(contagensQueryOptions());
+  const { summaryData: stats, countsData } = summaryData;
+
+  return (
+    <>
+      <AdminTopbar
+        title="Dashboard"
+        description="Visão geral dos dados gerenciáveis pela Ameciclo."
+      />
+      <div className="flex-1 px-6 py-6 space-y-6">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <StatCard label="Pontos de contagem" value={stats.different_counts_points} />
+          <StatCard label="Contagens registradas" value={stats.number_counts} />
+          <StatCard label="Ciclistas contados" value={stats.total_cyclists.toLocaleString("pt-BR")} />
+        </div>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Users2 className="size-4 text-muted-foreground" />
+              <CardTitle className="text-base">Contagens de ciclistas</CardTitle>
+            </div>
+            <Button asChild size="sm" variant="outline">
+              <Link to="/admin/contagens">
+                Gerenciar
+                <ArrowRight className="size-4" />
+              </Link>
+            </Button>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              {countsData.length.toLocaleString("pt-BR")} registros disponíveis para
+              consulta e edição.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: number | string }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-semibold tracking-tight">{value}</div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/routes/admin.route.tsx
+++ b/app/routes/admin.route.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { AdminSidebar } from "~/components/Admin/AdminSidebar";
+import { seo } from "~/utils/seo";
+
+export const Route = createFileRoute("/admin")({
+  head: () =>
+    seo({
+      title: "Admin - Ameciclo",
+      description: "Área administrativa para gestão de dados da Ameciclo.",
+      pathname: "/admin",
+      // Admin pages must not be indexed; robots.txt also disallows /admin.
+      noindex: true,
+    }),
+  component: AdminLayout,
+});
+
+function AdminLayout() {
+  return (
+    <div className="flex min-h-[calc(100vh-3.5rem)] bg-muted/30">
+      <AdminSidebar />
+      <div className="flex-1 min-w-0 flex flex-col">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/app/routes/robots[.]txt.ts
+++ b/app/routes/robots[.]txt.ts
@@ -10,6 +10,7 @@ export const Route = createFileRoute("/robots.txt")({
         const body = [
           "User-agent: *",
           "Allow: /",
+          "Disallow: /admin",
           "Disallow: /documentacao",
           "",
           `Sitemap: ${siteUrl}/sitemap.xml`,


### PR DESCRIPTION
## Summary
Stands up an `/admin` section with its own chrome (sidebar + topbar) so it doesn't inherit the public Navbar/Footer. Read-only UI scaffold for now — data is fetched from the existing public `contagensQueryOptions`; CRUD wiring is a follow-up once a write API is in place.

### Routes
- `GET /admin` — dashboard: stat cards (pontos / contagens / ciclistas) + link to contagens
- `GET /admin/contagens` — searchable, sortable table of all counts (Ponto / Data / Ciclistas / ações)

### Components
- `app/components/Admin/{AdminSidebar,AdminTopbar,ContagensTable}.tsx` — built on shadcn primitives + lucide icons
- shadcn primitives added: `card`, `table`, `input`, `badge`, `separator` (`button` was already in)
- Sidebar uses the new `--sidebar*` tokens from PR #159

### Wiring
- `__root.tsx` + `MainContent` skip the public Navbar/Footer and the `pt-14` main padding for `/admin` and `/admin/*` (extending the same `ConditionalNavbar/Footer` pattern already used for `/dados/ciclodados`)
- `robots.txt` now `Disallow: /admin`
- Both admin routes emit `noindex, nofollow` meta
- Sitemap uses an explicit allowlist, so admin is naturally excluded

### Misc
- `.tanstack/` added to `.gitignore` (TanStack Start dev tmp dir)

## Notes
- **No auth.** This is a UI shell — anyone visiting `/admin` will see it. We need to gate it before this becomes useful for writes. Easy follow-ups: HTTP basic auth at the Worker, Cloudflare Access, or a real auth provider.
- The "Editar" button on each row currently links to `/dados/contagens/{slug}` (the public detail page) as a placeholder. Replace once a real edit page exists.
- The "Nova contagem" button on `/admin/contagens` is `disabled` for the same reason.

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `/admin` and `/admin/contagens` return 200 in dev; sidebar links toggle active state
- [x] Public chrome (Navbar/Footer) does not leak into admin routes
- [x] `robots.txt` includes `Disallow: /admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)