### PR TITLE
prototype(admin/contagens): direct-manipulation flow diagram

### DIFF
--- a/app/components/Admin/NovaContagemForm.tsx
+++ b/app/components/Admin/NovaContagemForm.tsx
@@ -350,36 +350,13 @@ export function NovaContagemForm({ locations }: { locations: LocationOption[] })
             />
           </div>
 
-          <div className="grid gap-5 lg:grid-cols-2">
-            <div className="space-y-3">
-              <Label className="text-sm">Aproximações</Label>
-              <p className="text-xs text-muted-foreground">
-                Nomeie cada perna do {form.topology === "point" ? "trecho" : "cruzamento"}.
-                Os nomes aparecem no diagrama e nos cabeçalhos da matriz.
-              </p>
-              <div className="space-y-2">
-                {form.approaches.map((label, idx) => (
-                  <div key={idx} className="flex items-center gap-2">
-                    <span className="inline-flex size-6 items-center justify-center rounded-full bg-muted text-xs font-medium tabular-nums">
-                      {idx + 1}
-                    </span>
-                    <Input
-                      value={label}
-                      onChange={(e) => setApproach(idx, e.target.value)}
-                      placeholder={`Aproximação ${idx + 1}`}
-                      aria-label={`Nome da aproximação ${idx + 1}`}
-                    />
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <TopologyDiagram
-              topology={form.topology}
-              approaches={form.approaches}
-              movements={form.movements}
-            />
-          </div>
+          <TopologyDiagram
+            topology={form.topology}
+            approaches={form.approaches}
+            movements={form.movements}
+            onApproachChange={setApproach}
+            onMovementChange={setMovement}
+          />
         </CardContent>
       </Card>
 
@@ -435,20 +412,11 @@ export function NovaContagemForm({ locations }: { locations: LocationOption[] })
         <CardHeader>
           <CardTitle>Resultados</CardTitle>
           <CardDescription>
-            Movimentos contados de cada aproximação para as demais (sem retorno
-            na mesma perna). O total é calculado automaticamente.
+            Os movimentos são editados clicando nas setas do diagrama acima.
+            Use a tabela quando precisar revisar todos os valores de uma vez.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-5">
-          <MovementMatrix
-            approaches={form.approaches}
-            movements={form.movements}
-            onChange={setMovement}
-          />
-          {submitted && errors.movements && (
-            <p className="text-xs text-destructive">{errors.movements}</p>
-          )}
-
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="rounded-md border bg-muted/40 px-4 py-3 flex items-center justify-between">
               <span className="text-sm text-muted-foreground">Total de ciclistas</span>
@@ -472,6 +440,25 @@ export function NovaContagemForm({ locations }: { locations: LocationOption[] })
               />
             </Field>
           </div>
+
+          {submitted && errors.movements && (
+            <p className="text-xs text-destructive">{errors.movements}</p>
+          )}
+
+          <details className="rounded-md border bg-background group">
+            <summary className="cursor-pointer px-4 py-2.5 text-sm font-medium text-foreground select-none flex items-center justify-between">
+              <span>Ver matriz completa</span>
+              <span className="text-xs text-muted-foreground group-open:hidden">expandir</span>
+              <span className="text-xs text-muted-foreground hidden group-open:inline">recolher</span>
+            </summary>
+            <div className="px-4 pb-4 pt-2">
+              <MovementMatrix
+                approaches={form.approaches}
+                movements={form.movements}
+                onChange={setMovement}
+              />
+            </div>
+          </details>
         </CardContent>
       </Card>
 

--- a/app/components/Admin/topology/TopologyDiagram.tsx
+++ b/app/components/Admin/topology/TopologyDiagram.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import {
   TOPOLOGY_DIRECTIONS,
   type Movements,
@@ -8,18 +9,42 @@ type Props = {
   topology: Topology;
   approaches: string[];
   movements: Movements;
+  onApproachChange: (idx: number, value: string) => void;
+  onMovementChange: (key: string, value: string) => void;
 };
 
+type EditTarget =
+  | { kind: "approach"; idx: number }
+  | { kind: "movement"; key: string };
+
 /**
- * Static topology illustration. Each movement (from→to) with a non-zero count
- * is drawn as a cubic bezier whose tangents follow the leg axes, so straights
- * are straight, right-turns curve gently, and left/U-turns swing wide. Stroke
- * width and label scale subtly with magnitude.
+ * Interactive topology diagram. Click any approach label to rename it; click
+ * any movement curve to enter its count. Tab cycles through the labels and
+ * the live (or hover-discoverable) movements; Enter activates editing; Enter
+ * or blur commits; Escape cancels. The same `movements` and `approaches`
+ * state powers the read-only matrix view below.
  */
-export function TopologyDiagram({ topology, approaches, movements }: Props) {
+export function TopologyDiagram({
+  topology,
+  approaches,
+  movements,
+  onApproachChange,
+  onMovementChange,
+}: Props) {
   const dirs = TOPOLOGY_DIRECTIONS[topology];
   const count = dirs.length;
   const legs = LEG_GEOMETRY[topology];
+  const [editing, setEditing] = useState<EditTarget | null>(null);
+
+  // Reset editing state when topology shifts (indices/keys change).
+  useEffect(() => setEditing(null), [topology]);
+
+  function startEdit(target: EditTarget) {
+    setEditing(target);
+  }
+  function stopEdit() {
+    setEditing(null);
+  }
 
   return (
     <div className="rounded-md border bg-muted/30 px-4 py-4">
@@ -29,8 +54,8 @@ export function TopologyDiagram({ topology, approaches, movements }: Props) {
       <div className="flex justify-center">
         <svg
           viewBox="0 0 320 240"
-          className="w-full max-w-md"
-          aria-label="Diagrama da topologia da contagem com fluxo"
+          className="w-full max-w-lg"
+          aria-label="Diagrama interativo de fluxo"
         >
           <defs>
             <marker
@@ -44,49 +69,333 @@ export function TopologyDiagram({ topology, approaches, movements }: Props) {
             >
               <path d="M 0 0 L 6 3 L 0 6 z" fill="var(--color-ameciclo)" opacity="0.85" />
             </marker>
+            <marker
+              id="flow-tip-dim"
+              viewBox="0 0 6 6"
+              refX="5.5"
+              refY="3"
+              markerWidth="4"
+              markerHeight="4"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 6 3 L 0 6 z" fill="var(--color-ameciclo)" opacity="0.35" />
+            </marker>
           </defs>
 
-          {/* roads */}
           <Roads topology={topology} />
 
-          {/* movement curves (only non-zero) */}
+          {/* movement curves — render placeholders for zero-count too, dimmed */}
           {Array.from({ length: count }).flatMap((_, i) =>
             Array.from({ length: count }).map((__, j) => {
               if (i === j) return null;
-              const value = parseFlow(movements[`${i}-${j}`]);
-              if (value === 0) return null;
+              const key = `${i}-${j}`;
+              const value = parseFlow(movements[key]);
+              const isEditing = editing?.kind === "movement" && editing.key === key;
               return (
-                <FlowArrow
-                  key={`${i}-${j}`}
+                <FlowItem
+                  key={key}
+                  movementKey={key}
                   from={legs[i]}
                   to={legs[j]}
                   count={value}
+                  editing={isEditing}
+                  rawValue={movements[key] ?? ""}
+                  onActivate={() => startEdit({ kind: "movement", key })}
+                  onCommit={(v) => {
+                    onMovementChange(key, v);
+                    stopEdit();
+                  }}
+                  onCancel={stopEdit}
                 />
               );
             }),
           )}
 
-          {/* approach labels */}
+          {/* approach labels (clickable / editable) */}
           {dirs.map((_, idx) => {
             const leg = legs[idx];
-            const label = approaches[idx]?.trim() || `Aproximação ${idx + 1}`;
-            const placeholder = !approaches[idx]?.trim();
+            const value = approaches[idx] ?? "";
+            const isEditing = editing?.kind === "approach" && editing.idx === idx;
             return (
-              <LegLabel
+              <ApproachItem
                 key={idx}
+                idx={idx}
                 pos={leg.label}
-                label={label}
-                placeholder={placeholder}
+                value={value}
+                editing={isEditing}
+                onActivate={() => startEdit({ kind: "approach", idx })}
+                onCommit={(v) => {
+                  onApproachChange(idx, v);
+                  stopEdit();
+                }}
+                onCancel={stopEdit}
               />
             );
           })}
         </svg>
       </div>
       <p className="mt-3 text-xs text-muted-foreground text-center">
-        Cada seta vai <em>de</em> uma aproximação <em>para</em> outra. A
-        espessura e o número refletem a contagem na matriz abaixo.
+        Clique em um rótulo para renomear ou em uma seta para informar a contagem.
+        <span className="hidden sm:inline"> Use <kbd className="rounded border px-1 py-px text-[10px]">Tab</kbd> para navegar.</span>
       </p>
     </div>
+  );
+}
+
+/* ----- approach label (click to edit) ---------------------------------- */
+
+function ApproachItem({
+  idx,
+  pos,
+  value,
+  editing,
+  onActivate,
+  onCommit,
+  onCancel,
+}: {
+  idx: number;
+  pos: LegPos["label"];
+  value: string;
+  editing: boolean;
+  onActivate: () => void;
+  onCommit: (v: string) => void;
+  onCancel: () => void;
+}) {
+  const labelY = pos.side === "bottom" ? pos.y : pos.y - 4;
+  const placeholder = !value.trim();
+  const display = value.trim() || `Aproximação ${idx + 1}`;
+
+  if (editing) {
+    return (
+      <ForeignInput
+        x={pos.x - 80 + (pos.align === "end" ? 80 : pos.align === "middle" ? 40 : 0)}
+        y={labelY - 18}
+        width={160}
+        height={26}
+        initial={value}
+        type="text"
+        ariaLabel={`Renomear aproximação ${idx + 1}`}
+        onCommit={onCommit}
+        onCancel={onCancel}
+      />
+    );
+  }
+
+  return (
+    <g
+      tabIndex={0}
+      role="button"
+      aria-label={`Editar nome da aproximação ${idx + 1}: ${display}`}
+      onClick={onActivate}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onActivate();
+        }
+      }}
+      style={{ cursor: "pointer", outline: "none" }}
+      className="group focus-visible:[&_text]:underline"
+    >
+      <text
+        x={pos.x}
+        y={labelY}
+        textAnchor={pos.align}
+        fontSize={11}
+        fontWeight={600}
+        fontStyle={placeholder ? "italic" : "normal"}
+        fill={placeholder ? "var(--color-muted-foreground)" : "var(--color-foreground)"}
+        className="group-hover:fill-[var(--color-ameciclo)]"
+      >
+        {truncate(display, 24)}
+      </text>
+    </g>
+  );
+}
+
+/* ----- movement arrow (click to edit) ---------------------------------- */
+
+function FlowItem({
+  movementKey,
+  from,
+  to,
+  count,
+  editing,
+  rawValue,
+  onActivate,
+  onCommit,
+  onCancel,
+}: {
+  movementKey: string;
+  from: LegPos;
+  to: LegPos;
+  count: number;
+  editing: boolean;
+  rawValue: string;
+  onActivate: () => void;
+  onCommit: (v: string) => void;
+  onCancel: () => void;
+}) {
+  const start = from.out;
+  const end = to.in;
+  const c1: Pos = {
+    x: start.x + from.axis.x * TANGENT_LENGTH,
+    y: start.y + from.axis.y * TANGENT_LENGTH,
+  };
+  const c2: Pos = {
+    x: end.x + to.axis.x * TANGENT_LENGTH,
+    y: end.y + to.axis.y * TANGENT_LENGTH,
+  };
+  const mid: Pos = {
+    x: 0.125 * start.x + 0.375 * c1.x + 0.375 * c2.x + 0.125 * end.x,
+    y: 0.125 * start.y + 0.375 * c1.y + 0.375 * c2.y + 0.125 * end.y,
+  };
+
+  const hasValue = count > 0;
+  const width = hasValue
+    ? 1 + Math.min(1.6, Math.log10(count + 1) * 0.7)
+    : 1;
+  const opacity = hasValue ? 0.7 : 0.18;
+  const dPath = `M ${start.x} ${start.y} C ${c1.x} ${c1.y}, ${c2.x} ${c2.y}, ${end.x} ${end.y}`;
+
+  if (editing) {
+    return (
+      <>
+        <path d={dPath} fill="none" stroke="var(--color-ameciclo)" strokeOpacity={0.85} strokeWidth={width + 0.5} strokeLinecap="round" markerEnd="url(#flow-tip)" />
+        <ForeignInput
+          x={mid.x - 28}
+          y={mid.y - 12}
+          width={56}
+          height={24}
+          initial={rawValue}
+          type="number"
+          ariaLabel={`Contagem do movimento ${movementKey}`}
+          onCommit={onCommit}
+          onCancel={onCancel}
+        />
+      </>
+    );
+  }
+
+  return (
+    <g
+      tabIndex={0}
+      role="button"
+      aria-label={`Editar contagem do movimento ${movementKey} (${count})`}
+      onClick={onActivate}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onActivate();
+        }
+      }}
+      style={{ cursor: "pointer", outline: "none" }}
+      className="group"
+    >
+      {/* invisible fat hit-area for easier clicking */}
+      <path d={dPath} fill="none" stroke="transparent" strokeWidth={14} strokeLinecap="round" />
+      <path
+        d={dPath}
+        fill="none"
+        stroke="var(--color-ameciclo)"
+        strokeOpacity={opacity}
+        strokeWidth={width}
+        strokeLinecap="round"
+        markerEnd={hasValue ? "url(#flow-tip)" : "url(#flow-tip-dim)"}
+        className="group-hover:[stroke-opacity:1] group-focus-visible:[stroke-opacity:1]"
+      />
+      <text
+        x={mid.x}
+        y={mid.y}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        fontSize={hasValue ? 9 : 8}
+        fontWeight={600}
+        fontVariantNumeric="tabular-nums"
+        fill="var(--color-ameciclo)"
+        opacity={hasValue ? 1 : 0.45}
+        paintOrder="stroke"
+        stroke="var(--color-background)"
+        strokeWidth={3}
+        style={{ pointerEvents: "none" }}
+        className="group-hover:opacity-100"
+      >
+        {hasValue ? count.toLocaleString("pt-BR") : "+"}
+      </text>
+    </g>
+  );
+}
+
+/* ----- inline editing input via <foreignObject> ------------------------ */
+
+function ForeignInput({
+  x,
+  y,
+  width,
+  height,
+  initial,
+  type,
+  ariaLabel,
+  onCommit,
+  onCancel,
+}: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  initial: string;
+  type: "text" | "number";
+  ariaLabel: string;
+  onCommit: (v: string) => void;
+  onCancel: () => void;
+}) {
+  const [val, setVal] = useState(initial);
+  const ref = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+
+  return (
+    <foreignObject x={x} y={y} width={width} height={height}>
+      <input
+        ref={ref}
+        aria-label={ariaLabel}
+        type={type}
+        inputMode={type === "number" ? "numeric" : undefined}
+        min={type === "number" ? 0 : undefined}
+        step={type === "number" ? 1 : undefined}
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+        onBlur={() => onCommit(val)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            (e.currentTarget as HTMLInputElement).blur();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+        style={{
+          width: "100%",
+          height: "100%",
+          padding: type === "number" ? "0 4px" : "0 6px",
+          margin: 0,
+          border: "1.5px solid var(--color-ameciclo)",
+          borderRadius: 4,
+          background: "var(--color-background)",
+          color: "var(--color-foreground)",
+          fontSize: type === "number" ? 12 : 11,
+          fontWeight: 600,
+          fontVariantNumeric: "tabular-nums",
+          textAlign: type === "number" ? "center" : "left",
+          outline: "none",
+          boxShadow: "0 0 0 3px color-mix(in srgb, var(--color-ameciclo) 18%, transparent)",
+          fontFamily: "inherit",
+        }}
+      />
+    </foreignObject>
   );
 }
 
@@ -96,20 +405,15 @@ type Pos = { x: number; y: number };
 type Vec = { x: number; y: number };
 
 type LegPos = {
-  /** Outer end where the label sits. */
   label: Pos & {
     align: "start" | "middle" | "end";
     side: "top" | "right" | "bottom" | "left";
   };
-  /** Departure point (arrow leaves the leg here). */
   out: Pos;
-  /** Arrival point (arrow arrives the leg here). */
   in: Pos;
-  /** Unit vector pointing inward along the leg axis (from outer end to centre). */
   axis: Vec;
 };
 
-/** Right-hand convention: departure on the right side of the leg looking inward. */
 const LEG_GEOMETRY: Record<Topology, LegPos[]> = {
   point: [
     {
@@ -126,21 +430,18 @@ const LEG_GEOMETRY: Record<Topology, LegPos[]> = {
     },
   ],
   t_junction: [
-    // West
     {
       label: { x: 18, y: 100, align: "start", side: "left" },
       out: { x: 70, y: 112 },
       in: { x: 70, y: 88 },
       axis: { x: 1, y: 0 },
     },
-    // East
     {
       label: { x: 302, y: 100, align: "end", side: "right" },
       out: { x: 250, y: 88 },
       in: { x: 250, y: 112 },
       axis: { x: -1, y: 0 },
     },
-    // South
     {
       label: { x: 160, y: 215, align: "middle", side: "bottom" },
       out: { x: 148, y: 175 },
@@ -149,28 +450,24 @@ const LEG_GEOMETRY: Record<Topology, LegPos[]> = {
     },
   ],
   crossroad: [
-    // North
     {
       label: { x: 160, y: 18, align: "middle", side: "top" },
       out: { x: 172, y: 50 },
       in: { x: 148, y: 50 },
       axis: { x: 0, y: 1 },
     },
-    // East
     {
       label: { x: 302, y: 120, align: "end", side: "right" },
       out: { x: 270, y: 108 },
       in: { x: 270, y: 132 },
       axis: { x: -1, y: 0 },
     },
-    // South
     {
       label: { x: 160, y: 215, align: "middle", side: "bottom" },
       out: { x: 148, y: 190 },
       in: { x: 172, y: 190 },
       axis: { x: 0, y: -1 },
     },
-    // West
     {
       label: { x: 18, y: 120, align: "start", side: "left" },
       out: { x: 50, y: 132 },
@@ -193,9 +490,7 @@ function Roads({ topology }: { topology: Topology }) {
   const opacity = 0.07;
   const w = 30;
   if (topology === "point") {
-    return (
-      <line x1={20} y1={120} x2={300} y2={120} stroke={stroke} strokeWidth={w} opacity={opacity} strokeLinecap="round" />
-    );
+    return <line x1={20} y1={120} x2={300} y2={120} stroke={stroke} strokeWidth={w} opacity={opacity} strokeLinecap="round" />;
   }
   if (topology === "t_junction") {
     return (
@@ -210,94 +505,6 @@ function Roads({ topology }: { topology: Topology }) {
       <line x1={20} y1={120} x2={300} y2={120} />
       <line x1={160} y1={20} x2={160} y2={215} />
     </g>
-  );
-}
-
-function FlowArrow({
-  from,
-  to,
-  count,
-}: {
-  from: LegPos;
-  to: LegPos;
-  count: number;
-}) {
-  const start = from.out;
-  const end = to.in;
-
-  // Cubic bezier: enter along source axis, exit along destination axis.
-  // - Tangent at start = source axis (inward, toward intersection)
-  // - Tangent at end = -dest axis (outward, away from intersection)
-  const c1: Pos = {
-    x: start.x + from.axis.x * TANGENT_LENGTH,
-    y: start.y + from.axis.y * TANGENT_LENGTH,
-  };
-  const c2: Pos = {
-    x: end.x + to.axis.x * TANGENT_LENGTH,
-    y: end.y + to.axis.y * TANGENT_LENGTH,
-  };
-
-  // Subtle width scaling: 1.0–2.6 across counts 1..1000 (log-ish).
-  const width = 1 + Math.min(1.6, Math.log10(count + 1) * 0.7);
-
-  // Label at bezier midpoint t=0.5: 0.125 P0 + 0.375 C1 + 0.375 C2 + 0.125 P3
-  const mid: Pos = {
-    x: 0.125 * start.x + 0.375 * c1.x + 0.375 * c2.x + 0.125 * end.x,
-    y: 0.125 * start.y + 0.375 * c1.y + 0.375 * c2.y + 0.125 * end.y,
-  };
-
-  return (
-    <g>
-      <path
-        d={`M ${start.x} ${start.y} C ${c1.x} ${c1.y}, ${c2.x} ${c2.y}, ${end.x} ${end.y}`}
-        fill="none"
-        stroke="var(--color-ameciclo)"
-        strokeOpacity={0.7}
-        strokeWidth={width}
-        strokeLinecap="round"
-        markerEnd="url(#flow-tip)"
-      />
-      <text
-        x={mid.x}
-        y={mid.y}
-        textAnchor="middle"
-        dominantBaseline="middle"
-        fontSize={9}
-        fontWeight={600}
-        fontVariantNumeric="tabular-nums"
-        fill="var(--color-ameciclo)"
-        paintOrder="stroke"
-        stroke="var(--color-background)"
-        strokeWidth={3}
-      >
-        {count.toLocaleString("pt-BR")}
-      </text>
-    </g>
-  );
-}
-
-function LegLabel({
-  pos,
-  label,
-  placeholder,
-}: {
-  pos: LegPos["label"];
-  label: string;
-  placeholder: boolean;
-}) {
-  const labelY = pos.side === "bottom" ? pos.y : pos.y - 4;
-  return (
-    <text
-      x={pos.x}
-      y={labelY}
-      textAnchor={pos.align}
-      fontSize={11}
-      fontWeight={600}
-      fontStyle={placeholder ? "italic" : "normal"}
-      fill={placeholder ? "var(--color-muted-foreground)" : "var(--color-foreground)"}
-    >
-      {truncate(label, 24)}
-    </text>
   );
 }
 


### PR DESCRIPTION
## Summary
Prototype: the diagram becomes the primary input.

> Stacks on top of #161. Will rebase once that lands on `main`.

### How it works
- **Click any approach label** → renames it inline. Foreign-object `<input>` pops at the label position; type, Enter to commit, Esc to cancel.
- **Click any movement arrow** → enter its count inline. Same pattern.
- **Tab cycles through** labels + arrows in canonical order; **Enter** activates editing.
- **Empty (count = 0) movements are still drawn**, dim (~18 % opacity), with a smaller arrowhead so direction is visible before clicking, and a `+` at the curve midpoint to invite interaction. Hovering/focusing boosts opacity to 100 %.
- **Forgiving hit areas**: each curve has an invisible 14 px stroke beneath the visible one so the arrows are easy to click.

### Layout changes
- Dropped the side-panel "Aproximações" inputs — the diagram does that now.
- The full matrix moves into a `<details>` disclosure ("Ver matriz completa") under Resultados. Still editable; useful for reviewing all values at once.
- `Total de ciclistas` and `Pico em 1h` are now the primary content of the Resultados card.

### Known rough edges (it's a prototype)
- Two adjacent arrows that pass close to each other can shadow each other's hit areas at the centre of the intersection. Real cursor precision handles it; might want to nudge curves apart on follow-up.
- `<foreignObject>` inputs don't get spinner buttons styled exactly like the matrix `Input` component — close enough for prototyping.
- No undo. Esc cancels the in-flight edit; once committed it's just there.

### Sketches
1. Empty crossroad — all 12 dim arrows visible with directional tips and `+` placeholders.
2. Click an approach label → inline input pops at the label.
3. Click a movement arrow → inline number input pops at the curve midpoint.
4. Filled state — solid arrows for non-zero movements, dim arrows for the rest.

## Test plan
- [x] `pnpm build` succeeds
- [x] Click label → rename; click arrow → set count; both update the matrix below
- [x] All 12 movements remain clickable on a populated crossroad
- [ ] Keyboard-only walkthrough (Tab + Enter + numeric input + Enter to commit, Esc to cancel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)