### PR TITLE
chore: update Strapi production URL to strapi.ameciclo.org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # APIs Externas
 API_GARFO_URL=http://api.garfo.ameciclo.org
-CMS_BASE_URL=http://do.strapi.ameciclo.org
+CMS_BASE_URL=https://strapi.ameciclo.org
 
 # Mapbox (obtenha em https://mapbox.com)
 MAPBOX_ACCESS_TOKEN=seu_token_mapbox_aqui

--- a/app/components/Documentacao/API.tsx
+++ b/app/components/Documentacao/API.tsx
@@ -26,9 +26,9 @@ export default function API({ darkMode = true, fontSize = 16 }: DocumentationCom
               
               <div className={`${darkMode ? 'bg-gray-700' : 'bg-gray-100'} p-4 rounded-sm`}>
                 <div className={`font-semibold ${darkMode ? 'text-green-400' : 'text-green-700'} mb-2`} style={{ fontSize: fontSize }}>CMS Strapi - Conteúdo</div>
-                <code className={`text-sm ${darkMode ? 'text-gray-300' : 'text-gray-700'} block mb-2`} style={{ fontSize: fontSize - 2 }}>GET http://do.strapi.ameciclo.org/api/projetos</code>
+                <code className={`text-sm ${darkMode ? 'text-gray-300' : 'text-gray-700'} block mb-2`} style={{ fontSize: fontSize - 2 }}>GET https://strapi.ameciclo.org/api/projetos</code>
                 <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-600'} mb-2`} style={{ fontSize: fontSize - 2 }}>Lista de projetos da organização</p>
-                <code className={`text-sm ${darkMode ? 'text-gray-300' : 'text-gray-700'} block`} style={{ fontSize: fontSize - 2 }}>GET http://do.strapi.ameciclo.org/api/projetos/:slug</code>
+                <code className={`text-sm ${darkMode ? 'text-gray-300' : 'text-gray-700'} block`} style={{ fontSize: fontSize - 2 }}>GET https://strapi.ameciclo.org/api/projetos/:slug</code>
                 <p className={`text-sm ${darkMode ? 'text-gray-400' : 'text-gray-600'}`} style={{ fontSize: fontSize - 2 }}>Detalhes de um projeto</p>
               </div>
 

--- a/app/components/Documentacao/Configuracao.tsx
+++ b/app/components/Documentacao/Configuracao.tsx
@@ -19,7 +19,7 @@ export default function Configuracao({ darkMode = true, fontSize = 16 }: Documen
               <code className={`${darkMode ? "text-green-300" : "text-green-700"}`} style={{ fontSize: fontSize - 2 }}>
                 # APIs Externas<br />
                 API_GARFO_URL=http://api.garfo.ameciclo.org<br />
-                CMS_BASE_URL=http://do.strapi.ameciclo.org<br /><br />
+                CMS_BASE_URL=https://strapi.ameciclo.org<br /><br />
                 # Mapbox<br />
                 MAPBOX_ACCESS_TOKEN=pk.seu_token_aqui<br /><br />
                 # Google Calendar<br />

--- a/app/lib/strapi.ts
+++ b/app/lib/strapi.ts
@@ -1,5 +1,5 @@
 import { strapi } from "@strapi/client";
 
-const STRAPI_BASE_URL = "https://do.strapi.ameciclo.org/api";
+const STRAPI_BASE_URL = "https://strapi.ameciclo.org/api";
 
 export const strapiClient = strapi({ baseURL: STRAPI_BASE_URL });

--- a/app/servers.ts
+++ b/app/servers.ts
@@ -1,4 +1,4 @@
-export const CMS_BASE_URL = "https://do.strapi.ameciclo.org"
+export const CMS_BASE_URL = "https://strapi.ameciclo.org"
 
 // Strapi single-types still consumed by unmigrated dados routes.
 export const COUNTINGS_PAGE_DATA = `${CMS_BASE_URL}/api/contagem?populate=*`


### PR DESCRIPTION
## Summary
- Production Strapi CMS moved from `do.strapi.ameciclo.org` to `strapi.ameciclo.org`
- Updated `CMS_BASE_URL` in `app/servers.ts` and `.env.example`, the Strapi client base URL in `app/lib/strapi.ts`, and the example URLs shown in the Documentação pages (`API.tsx`, `Configuracao.tsx`)

## Test plan
- [x] Verify data still loads from Strapi-backed pages (projetos, dom, ideciclo, loa, contagem) against the new URL
- [x] Confirm `strapi.ameciclo.org` resolves and serves the same API

🤖 Generated with [Claude Code](https://claude.com/claude-code)