### PR TITLE
chore: deploy staging on push to dev

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,60 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: staging
+      url: https://staging.ameciclo.org
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: jdx/mise-action@v4
+        with:
+          cache: true
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+
+      # The Cloudflare Vite plugin resolves the Wrangler environment HERE, at
+      # build time, and flattens it into dist/server/wrangler.json. This env var
+      # is the only thing that selects staging.
+      - run: pnpm build
+        env:
+          CLOUDFLARE_ENV: staging
+
+      # Deliberately no `--env staging`. Wrangler reads the already-flattened
+      # config produced above (via .wrangler/deploy/config.json), which has no
+      # `env` block left to select from — so `--env` is silently ignored and
+      # would only create false confidence. See:
+      # https://developers.cloudflare.com/workers/wrangler/environments/
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          packageManager: pnpm
+          command: deploy

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "deploy": "vite build && wrangler deploy",
+    "deploy:staging": "CLOUDFLARE_ENV=staging vite build && wrangler deploy",
     "lint": "oxlint",
     "typecheck": "tsc",
     "gen:strapi-types": "openapi-typescript ./specification.json -o ./app/types/strapi-api.ts"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "ameciclo",
+  "account_id": "8b9af9b81476222e1a787f42f3c8076a",
   "workers_dev": true,
   "preview_urls": true,
   "routes": [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,16 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "ameciclo",
-  "account_id": "8b9af9b81476222e1a787f42f3c8076a",
-  /**
-   * `workers_dev: true` exposes the Worker on
-   * <name>.<account-subdomain>.workers.dev (ameciclo.ti-8b9.workers.dev).
-   * `preview_urls: true` lets `wrangler versions upload --preview-alias`
-   * produce per-version URLs like pr-<N>-ameciclo.ti-8b9.workers.dev,
-   * which the PR Preview workflow surfaces as a sticky comment.
-   *
-   * Production traffic still goes to the custom domains in `routes`.
-   */
   "workers_dev": true,
   "preview_urls": true,
   "routes": [
@@ -45,4 +35,17 @@
     "GOOGLE_CALENDAR_EXTERNAL_ID": "oj4bkgv1g6cmcbtsap4obgi9vc@group.calendar.google.com",
     "GOOGLE_CALENDAR_INTERNAL_ID": "ameciclo@gmail.com",
   },
+
+  "env": {
+    "staging": {
+      "routes": [
+        { "pattern": "staging.ameciclo.org", "custom_domain": true },
+      ],
+      "vars": {
+        "SITE_URL": "https://staging.ameciclo.org",
+        "GOOGLE_CALENDAR_EXTERNAL_ID": "oj4bkgv1g6cmcbtsap4obgi9vc@group.calendar.google.com",
+        "GOOGLE_CALENDAR_INTERNAL_ID": "ameciclo@gmail.com",
+      },
+    }
+  }
 }


### PR DESCRIPTION
## O que faz

Push em `dev` passa a fazer deploy para `staging.ameciclo.org`.

- `.github/workflows/deploy-staging.yml` — espelha `deploy.yml` (mise, cache do pnpm store, lockfile congelado)
- `wrangler.jsonc` — bloco `env.staging`
- `package.json` — script `deploy:staging`

## O detalhe que importa

O plugin Vite da Cloudflare resolve o ambiente em **tempo de build** via `CLOUDFLARE_ENV` e achata a config em `dist/server/wrangler.json` (redirect por `.wrangler/deploy/config.json`). Quando o `wrangler deploy` roda, não existe mais bloco `env` para selecionar — então `--env staging` é **silenciosamente ignorado** e faz deploy do que foi buildado.

Verificado: com `CLOUDFLARE_ENV=staging`, `wrangler deploy --dry-run` com e sem `--env staging` produzem binding idêntico (`SITE_URL=https://staging.ameciclo.org`).

Por isso o workflow usa `CLOUDFLARE_ENV: staging` no build e **não** passa `--env` no deploy. Há um comentário no YAML explicando, para evitar que alguém "conserte" isso depois.

Ref: https://developers.cloudflare.com/workers/wrangler/environments/ — *"If you're using the Cloudflare Vite plugin, you select the environment at dev or build time via the `CLOUDFLARE_ENV` environment variable rather than the `--env` flag."*

## Notas

- O nome `ameciclo-staging` é derivado automaticamente (`<top-level>-<env>`), não declarado. Confirmado que bate com o Worker já existente.
- `ameciclo-staging` e `staging.ameciclo.org` já existem e respondem 200 — este PR não provisiona nada.
- `account_id` sai do `wrangler.jsonc`; os deploys passam a inferir a conta pelo `CLOUDFLARE_API_TOKEN`.
- `concurrency` de staging usa `cancel-in-progress: true` (produção segue `false`).

## Depois do merge

`dev` está 33 commits atrás de `main` e é anterior à migração para TanStack (ainda tem `remix.config.cjs`). Merge de `main` em `dev` dá 11 conflitos, incluindo modify/delete. O plano é arquivar `dev` em `archive/dev-remix-i18n` e resetá-la para `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)